### PR TITLE
python-validity: fix PyPA build

### DIFF
--- a/pkgs/python-validity/default.nix
+++ b/pkgs/python-validity/default.nix
@@ -74,11 +74,6 @@ in buildPythonPackage rec {
     pygobject3
   ];
 
-  # circumvent known bug in setuptools regarding data file installation: https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/python.section.md#install_data--data_files-problems-install_data-data_files-problems
-  preInstall = ''
-    ${python.interpreter} setup.py install_data --install-dir=$out --root=$out
-  '';
-
   postInstall = ''
     # this section has been adapted from this AUR package https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-validity
 


### PR DESCRIPTION
Since https://github.com/NixOS/nixpkgs/pull/248866/commits/6c85fff302615c62bf4f632bca661bc48298b0a3, buildPythonPackage uses `pypa{Build,Install}Hook` for setuptools-based python packages rather than the older `pip{Build,Install}Hook`s. `pypaInstallHook` appears to have more stringent testing than its predecessor, yielding the following error:

> FileExistsError: File already exists: /nix/store/[...]-python3.10-python-validity-0.14/share/dbus-1/system.d/io.github.uunicorn.Fprint.conf

Removing the workaround doesn't appear to cause problems, and seemingly works just fine with `pipInstallHook` as well: whatever necessitated its addition was presumably fixed in the interim, with installation of the resource files being silently duplicated, until now.