### PR TITLE
Fix verbose logging slowing down authentication

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702645756,
-        "narHash": "sha256-qKI6OR3TYJYQB3Q8mAZ+DG4o/BR9ptcv9UnRV2hzljc=",
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "40c3c94c241286dd2243ea34d3aef8a488f9e4d0",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
         "type": "github"
       },
       "original": {

--- a/pkgs/fprintd-clients/default.nix
+++ b/pkgs/fprintd-clients/default.nix
@@ -18,7 +18,7 @@ fprintd.overrideAttrs ({
     mesonFlags
     ++ [
       (lib.mesonBool "daemon" false)
-      (lib.mesonBool "pam" false)
+      (lib.mesonBool "pam" true)
       (lib.mesonBool "systemd" false)
     ];
 

--- a/pkgs/fprintd-clients/default.nix
+++ b/pkgs/fprintd-clients/default.nix
@@ -2,18 +2,25 @@
 # It provides the fprintd-enroll, fprintd-list, etc. user utilties when using open-fprintd.
 #
 # Beyond installing only a subset of its files, there are no actual differences from the fprintd package in Nixpkgs.
-
-{ lib, fprintd }:
-
-fprintd.overrideAttrs ({ patches ? [], mesonFlags ? [], ... }: {
+{
+  lib,
+  fprintd,
+}:
+fprintd.overrideAttrs ({
+  patches ? [],
+  mesonFlags ? [],
+  ...
+}: {
   pname = "fprintd-clients";
 
-  patches = patches ++ [ ./Make-building-the-daemon-optional.patch ];
-  mesonFlags = mesonFlags ++ [
-    (lib.mesonBool "daemon" false)
-    (lib.mesonBool "pam" false)
-    (lib.mesonBool "systemd" false)
-  ];
+  patches = patches ++ [./Make-building-the-daemon-optional.patch];
+  mesonFlags =
+    mesonFlags
+    ++ [
+      (lib.mesonBool "daemon" false)
+      (lib.mesonBool "pam" true)
+      (lib.mesonBool "systemd" false)
+    ];
 
   meta.homepage = "https://gitlab.freedesktop.org/uunicorn/fprintd/-/tree/debian/clients-only";
   meta.description = "fprintd without the daemon";

--- a/pkgs/fprintd-clients/default.nix
+++ b/pkgs/fprintd-clients/default.nix
@@ -18,7 +18,7 @@ fprintd.overrideAttrs ({
     mesonFlags
     ++ [
       (lib.mesonBool "daemon" false)
-      (lib.mesonBool "pam" true)
+      (lib.mesonBool "pam" false)
       (lib.mesonBool "systemd" false)
     ];
 

--- a/pkgs/libfprint-2-tod1-vfs0090-bingch/default.nix
+++ b/pkgs/libfprint-2-tod1-vfs0090-bingch/default.nix
@@ -7,7 +7,7 @@
 # This file is mostly based on https://github.com/NixOS/nixpkgs/blob/nixos-22.11/pkgs/development/libraries/libfprint-2-tod1-vfs0090/default.nix#L36
 # with a few small modifications.
 #
-{ stdenv, lib, fetchFromGitLab, pkg-config, libfprint-tod, gusb, udev, nss, openssl, meson, pixman, ninja, glib, python3, python3Packages, python-validity, calib-data }:
+{ stdenv, lib, fetchFromGitLab, pkg-config, libfprint-tod, gusb, udev, nss, openssl, meson, pixman, ninja, glib, python3, python3Packages, python-validity, calib-data, autoPatchelfHook }:
 stdenv.mkDerivation {
   pname = "libfprint-2-tod1-vfs0090";
   version = "0.8.5";
@@ -37,7 +37,7 @@ stdenv.mkDerivation {
       --replace "calib_data_path" "'${calib-data}/share/calib-data.bin'"
   '';
 
-  nativeBuildInputs = [ pkg-config meson ninja python3 python-validity ];
+  nativeBuildInputs = [ pkg-config meson ninja python3 python-validity  autoPatchelfHook ];
   buildInputs = [ libfprint-tod glib gusb udev nss openssl pixman ];
 
   installPhase = ''

--- a/pkgs/python-validity/default.nix
+++ b/pkgs/python-validity/default.nix
@@ -3,93 +3,93 @@
   lib,
   stdenv,
   fetchFromGitHub,
-  python3Packages
-}:
-
-let
+  python3Packages,
+}: let
   inherit (python3Packages) python buildPythonPackage;
-in buildPythonPackage rec {
-  pname = "python-validity";
-  version = "0.14";
+in
+  buildPythonPackage rec {
+    pname = "python-validity";
+    version = "0.14";
 
-  src = fetchFromGitHub {
-    owner = "uunicorn";
-    repo = pname;
-    rev = "${version}";
-    sha256 = "sha256-6NbxeokbGW5yP3g9Q/W3k0JiU6g+qyeZfKfw0nBJ37o="; # set to lib.fakeSha256 first to get the hash
-  };
+    src = fetchFromGitHub {
+      owner = "uunicorn";
+      repo = pname;
+      rev = "${version}";
+      sha256 = "sha256-6NbxeokbGW5yP3g9Q/W3k0JiU6g+qyeZfKfw0nBJ37o="; # set to lib.fakeSha256 first to get the hash
+    };
 
-  patches = [
-    # the service writes to a temporary file in usr/share, which is write-protected in Nix.
-    # Instead, we let it write to the appropriate location for temporary files
-    ./dbus-service.patch
+    patches = [
+      # the service writes to a temporary file in usr/share, which is write-protected in Nix.
+      # Instead, we let it write to the appropriate location for temporary files
+      ./dbus-service.patch
 
-    # similarly, state data needs to go to /var/lib
-    ./sensor.py.patch
+      # similarly, state data needs to go to /var/lib
+      ./sensor.py.patch
 
-    # rename dbus service executable
-    ./python-validity-dbus-service.patch
+      # rename dbus service executable
+      ./python-validity-dbus-service.patch
 
-    # in the original setup.py, the dbus-service executable is not installed in /bin, but as a data file to a non-standard location.
-    # Hence, we remove its declaration as a data file and declare it as a script instead, so that it is installed to /bin.
-    # This is because the buildPythonPackage wrapper will only wrap the executable correctly if it is in the /bin directory
-    ./setup.py.patch
+      # in the original setup.py, the dbus-service executable is not installed in /bin, but as a data file to a non-standard location.
+      # Hence, we remove its declaration as a data file and declare it as a script instead, so that it is installed to /bin.
+      # This is because the buildPythonPackage wrapper will only wrap the executable correctly if it is in the /bin directory
+      ./setup.py.patch
 
-    # The firmware download script is run as part of the installation process on other distributions.
-    # However, it tries to identify the system hardware and download different firmware packages depending on the results.
-    # 
-    # This sort of side-effect related behaviour is probably not ideal to have in the build process of a Nix package.
-    # Instead, the user shall call `validity-sensors-firmware` themselves when using python validity for the first time.
-    # TODO: We should make it so, that the python-validity service downloads the firmware automatically when not present.
-    #
-    # Hence, we patch the firmware download script so that it downloads the firmware to a temporary directory, instead of trying
-    # to write to /usr/share or the Nix store
-    ./validity-sensors-firmware.patch
+      # The firmware download script is run as part of the installation process on other distributions.
+      # However, it tries to identify the system hardware and download different firmware packages depending on the results.
+      #
+      # This sort of side-effect related behaviour is probably not ideal to have in the build process of a Nix package.
+      # Instead, the user shall call `validity-sensors-firmware` themselves when using python validity for the first time.
+      # TODO: We should make it so, that the python-validity service downloads the firmware automatically when not present.
+      #
+      # Hence, we patch the firmware download script so that it downloads the firmware to a temporary directory, instead of trying
+      # to write to /usr/share or the Nix store
+      ./validity-sensors-firmware.patch
 
-    # Because of the above firmware downloading patch, we also have patch the firmware search location in the script which
-    # performs the firmware installation
-    ./upload_fwext.py.patch
-  ];
+      # Because of the above firmware downloading patch, we also have patch the firmware search location in the script which
+      # performs the firmware installation
+      ./upload_fwext.py.patch
+    ];
 
-  postPatch = ''
-    # add support for using a temporary directory, which is needed for multiple of the above patches
-    cp ${./tmpdir.py} validitysensor/tmpdir.py
+    postPatch = ''
+      # add support for using a temporary directory, which is needed for multiple of the above patches
+      cp ${./tmpdir.py} validitysensor/tmpdir.py
 
-    # the firmware download script depends on innoextract
-    substituteInPlace bin/validity-sensors-firmware \
-          --replace "'innoextract'" \
-                    "'${pkgs.innoextract}/bin/innoextract'"
+      # the firmware download script depends on innoextract
+      substituteInPlace bin/validity-sensors-firmware \
+            --replace "'innoextract'" \
+                      "'${pkgs.innoextract}/bin/innoextract'"
 
-    # change service file to use the new executable path
-    substituteInPlace debian/python3-validity.service \
-          --replace "ExecStart=/usr/lib/python-validity/dbus-service" \
-                    "ExecStart=$out/bin/python-validity-dbus-service"
-  '';
+      # change service file to use the new executable path
+      substituteInPlace debian/python3-validity.service \
+            --replace "ExecStart=/usr/lib/python-validity/dbus-service" \
+                      "ExecStart=$out/bin/python-validity-dbus-service" \
+            --replace " --debug" ""
+    '';
 
-  propagatedBuildInputs = with python3Packages; [
-    cryptography
-    pyusb
-    pyyaml
-    dbus-python
-    pygobject3
-  ];
+    propagatedBuildInputs = with python3Packages; [
+      cryptography
+      pyusb
+      pyyaml
+      dbus-python
+      pygobject3
+    ];
 
-  postInstall = ''
-    # this section has been adapted from this AUR package https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-validity
+    postInstall = ''
+      # this section has been adapted from this AUR package https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=python-validity
 
-    install -D -m 644 debian/python3-validity.service \
-      $out/lib/systemd/system/python3-validity.service
+      install -D -m 644 debian/python3-validity.service \
+        $out/lib/systemd/system/python3-validity.service
 
-    install -D -m 644 debian/python3-validity.udev \
-      $out/lib/udev/rules.d/60-python-validity.rules
+      install -D -m 644 debian/python3-validity.udev \
+        $out/lib/udev/rules.d/60-python-validity.rules
 
-    install -Dm644 LICENSE \
-      $out/share/licenses/${pname}/LICENSE
-  '';
+      install -Dm644 LICENSE \
+        $out/share/licenses/${pname}/LICENSE
+    '';
 
-  meta = with lib; {
-    description = "Validity fingerprint sensor driver";
-    homepage = "https://github.com/uunicorn/python-validity";
-    license = licenses.mit;
-  };
-}
+    meta = with lib; {
+      description = "Validity fingerprint sensor driver";
+      homepage = "https://github.com/uunicorn/python-validity";
+      license = licenses.mit;
+    };
+  }


### PR DESCRIPTION
Hi, 

Thanks for this great package. I noticed in the service per upstream has `--debug` hardcoded in it's service. After disabling that flag, authentication on my machine is significantly faster...

I just now see vscode fd-up the formatting, ill fix that shortly.

Todo:
- [ ] undo automatic formatting
- [ ] make debug flag configurable?