### PR TITLE
docs: update attribute name for module

### DIFF
--- a/SETUP-24.11.md
+++ b/SETUP-24.11.md
@@ -40,7 +40,7 @@ outputs = {
     # ...
     modules = [
       # ...
-      nixos-06cb-009a-fingerprint-sensor.nixosModules."nixos-06cb-009a-fingerprint-sensor"
+      nixos-06cb-009a-fingerprint-sensor.nixosModules."06cb-009a-fingerprint-sensor"
     ];
   };
 };


### PR DESCRIPTION
The attribute does not have the `nixos-` prefix, causing the build to fail.

Continuation from #15